### PR TITLE
Refactor test assertions for handlers and ID generation

### DIFF
--- a/internal/handler/health_handler_test.go
+++ b/internal/handler/health_handler_test.go
@@ -1,4 +1,3 @@
-
 package handler
 
 import (

--- a/internal/handler/health_handler_test.go
+++ b/internal/handler/health_handler_test.go
@@ -1,9 +1,13 @@
+
 package handler
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealthHandler(t *testing.T) {
@@ -13,10 +17,7 @@ func TestHealthHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rw := httptest.NewRecorder()
 	mux.ServeHTTP(rw, req)
-	if rw.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rw.Code)
-	}
-	if got := rw.Body.String(); got != "{\"ok\":true}\n" {
-		t.Errorf("unexpected body: %s", got)
-	}
+
+	require.Equal(t, http.StatusOK, rw.Code, "expected 200 OK")
+	assert.Equal(t, "{\"ok\":true}\n", rw.Body.String(), "unexpected body")
 }

--- a/internal/handler/service_handler_test.go
+++ b/internal/handler/service_handler_test.go
@@ -1,4 +1,3 @@
-
 package handler
 
 import (

--- a/internal/handler/service_handler_test.go
+++ b/internal/handler/service_handler_test.go
@@ -1,9 +1,13 @@
+
 package handler
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceHandler(t *testing.T) {
@@ -13,10 +17,7 @@ func TestServiceHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	rw := httptest.NewRecorder()
 	mux.ServeHTTP(rw, req)
-	if rw.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rw.Code)
-	}
-	if got := rw.Body.String(); got != "{\"service\":\"taskmanager\"}\n" {
-		t.Errorf("unexpected body: %s", got)
-	}
+
+	require.Equal(t, http.StatusOK, rw.Code, "expected 200 OK")
+	assert.Equal(t, "{\"service\":\"taskmanager\"}\n", rw.Body.String(), "unexpected body")
 }

--- a/internal/handler/task_handler_integration_test.go
+++ b/internal/handler/task_handler_integration_test.go
@@ -1,4 +1,3 @@
-
 package handler
 
 import (

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -1,10 +1,9 @@
-
 package idgen
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestGenerateTaskID_UniqueAndValid(t *testing.T) {

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -1,19 +1,18 @@
+
 package idgen
 
 import (
 	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateTaskID_UniqueAndValid(t *testing.T) {
 	ids := make(map[string]struct{})
 	for i := 0; i < 1000; i++ {
 		id := GenerateTaskID()
-		if _, exists := ids[id]; exists {
-			t.Fatalf("duplicate id generated: %s", id)
-		}
+		require.NotContains(t, ids, id, "duplicate id generated: %s", id)
 		ids[id] = struct{}{}
-		if len(id) != 36 {
-			t.Errorf("id length is not 36: %s", id)
-		}
+		assert.Equal(t, 36, len(id), "id length is not 36: %s", id)
 	}
 }


### PR DESCRIPTION
Enhance test assertions in health, service, and task handlers for improved clarity and reliability. Use testify's assert and require for better error handling and readability.